### PR TITLE
Add support for execution identity to RsapiDao

### DIFF
--- a/Gravity/Gravity.Test/RsapiDaoTest.cs
+++ b/Gravity/Gravity.Test/RsapiDaoTest.cs
@@ -7,6 +7,8 @@ using Gravity.Test.TestClasses;
 
 namespace Gravity.Test
 {
+	using Relativity.API;
+
 	[TestClass]
 	public class RsapiDaoTest : BaseTest
 	{
@@ -19,7 +21,7 @@ namespace Gravity.Test
 
 			int workspaceId = Convert.ToInt32(ConfigurationManager.AppSettings["WorkspaceID"]);
 
-			gravityRsapiDao = new RsapiDao(base.Helper, workspaceId);
+			gravityRsapiDao = new RsapiDao(base.Helper, workspaceId, ExecutionIdentity.System);
 		}
 
 		[TestMethod]

--- a/Gravity/Gravity/DAL/RSAPI/RsapiDao.cs
+++ b/Gravity/Gravity/DAL/RSAPI/RsapiDao.cs
@@ -9,25 +9,26 @@ namespace Gravity.DAL.RSAPI
 
 	public partial class RsapiDao
 	{
+		public ExecutionIdentity CurrentExecutionIdentity { get; set; }
+
 		protected IHelper helper;
 		protected int workspaceId;
-		protected ExecutionIdentity currentExecutionIdentity;
+		
+		private InvokeWithRetryService invokeWithRetryService;
 
 		protected IRSAPIClient CreateProxy()
 		{
-			var proxy = helper.GetServicesManager().CreateProxy<IRSAPIClient>(this.currentExecutionIdentity);
+			var proxy = helper.GetServicesManager().CreateProxy<IRSAPIClient>(this.CurrentExecutionIdentity);
 			proxy.APIOptions.WorkspaceID = workspaceId;
 
 			return proxy;
 		}
-
-		private InvokeWithRetryService invokeWithRetryService;
-
+		
 		public RsapiDao(IHelper helper, int workspaceId, ExecutionIdentity executionIdentity, InvokeWithRetrySettings invokeWithRetrySettings = null)
 		{
 			this.helper = helper;
 			this.workspaceId = workspaceId;
-			this.currentExecutionIdentity = executionIdentity;
+			this.CurrentExecutionIdentity = executionIdentity;
 
 			if (invokeWithRetrySettings == null)
 			{

--- a/Gravity/Gravity/DAL/RSAPI/RsapiDao.cs
+++ b/Gravity/Gravity/DAL/RSAPI/RsapiDao.cs
@@ -5,14 +5,17 @@ using Gravity.Utils;
 
 namespace Gravity.DAL.RSAPI
 {
+	using System;
+
 	public partial class RsapiDao
 	{
 		protected IHelper helper;
 		protected int workspaceId;
+		protected ExecutionIdentity currentExecutionIdentity;
 
 		protected IRSAPIClient CreateProxy()
 		{
-			var proxy = helper.GetServicesManager().CreateProxy<IRSAPIClient>(ExecutionIdentity.System);
+			var proxy = helper.GetServicesManager().CreateProxy<IRSAPIClient>(this.currentExecutionIdentity);
 			proxy.APIOptions.WorkspaceID = workspaceId;
 
 			return proxy;
@@ -20,10 +23,11 @@ namespace Gravity.DAL.RSAPI
 
 		private InvokeWithRetryService invokeWithRetryService;
 
-		public RsapiDao(IHelper helper, int workspaceId, InvokeWithRetrySettings invokeWithRetrySettings = null)
+		public RsapiDao(IHelper helper, int workspaceId, ExecutionIdentity executionIdentity, InvokeWithRetrySettings invokeWithRetrySettings = null)
 		{
 			this.helper = helper;
 			this.workspaceId = workspaceId;
+			this.currentExecutionIdentity = executionIdentity;
 
 			if (invokeWithRetrySettings == null)
 			{
@@ -34,6 +38,12 @@ namespace Gravity.DAL.RSAPI
 			{
 				this.invokeWithRetryService = new InvokeWithRetryService(invokeWithRetrySettings);
 			}
+		}
+
+		[Obsolete("This constructor has been deprecated. Use RsapiDao(IHelper helper, int workspaceId, ExecutionIdentity executionIdentity, InvokeWithRetrySettings invokeWithRetrySettings) instead.")]
+		public RsapiDao(IHelper helper, int workspaceId, InvokeWithRetrySettings invokeWithRetrySettings = null)
+			: this(helper, workspaceId, ExecutionIdentity.System, invokeWithRetrySettings)
+		{
 		}
 	}
 }


### PR DESCRIPTION
This adds support for setting the execution identity to RsapiDao. I have set the existing constructor to obsolete in order to move users to the new constructor without causing a breaking change for existing users. If there is another way for adding this support people would like to see let me know and I can make this change.
#4 