### PR TITLE
Use nuget packages

### DIFF
--- a/Gravity.Demo/Gravity.Demo.EventHandlers/Gravity.Demo.EventHandlers.csproj
+++ b/Gravity.Demo/Gravity.Demo.EventHandlers/Gravity.Demo.EventHandlers.csproj
@@ -30,14 +30,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="kCura.EventHandler">
-      <HintPath>..\..\..\TSDLionbridgeRepository\bin\9.3\kCura.EventHandler.dll</HintPath>
+    <Reference Include="kCura.EventHandler, Version=9.5.162.111, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\Relativity.EventHandler.9.5.162.111\lib\kCura.EventHandler.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Relativity.Client">
-      <HintPath>..\..\..\TSDLionbridgeRepository\bin\9.3\kCura.Relativity.Client.dll</HintPath>
+    <Reference Include="kCura.Relativity.Client, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.Rsapi.9.5.162.111\lib\kCura.Relativity.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.API">
-      <HintPath>..\..\..\TSDLionbridgeRepository\bin\9.3\Relativity.API.dll</HintPath>
+    <Reference Include="Relativity.API, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.Api.9.5.162.111\lib\Relativity.API.dll</HintPath>
+    </Reference>
+    <Reference Include="Relativity.Kepler, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Kepler.dll</HintPath>
+    </Reference>
+    <Reference Include="Relativity.Services.DataContracts, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.DataContracts.dll</HintPath>
+    </Reference>
+    <Reference Include="Relativity.Services.Interfaces, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.ServiceProxy.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -63,6 +75,9 @@
       <Project>{cfa21c47-85e1-47b9-a824-7cd3989c9998}</Project>
       <Name>Gravity</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Gravity.Demo/Gravity.Demo.EventHandlers/packages.config
+++ b/Gravity.Demo/Gravity.Demo.EventHandlers/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Relativity.Api" version="9.5.162.111" targetFramework="net452" />
+  <package id="Relativity.EventHandler" version="9.5.162.111" targetFramework="net452" />
+  <package id="Relativity.ObjectManager" version="9.5.162.111" targetFramework="net452" />
+  <package id="Relativity.Rsapi" version="9.5.162.111" targetFramework="net452" />
+</packages>

--- a/Gravity/Gravity.Test/App.config
+++ b/Gravity/Gravity.Test/App.config
@@ -17,4 +17,4 @@
 	<add key="SMTPUsername" value="user"/>
 	<add key="SMTPPassword" value="pass"/>
   </appSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/></startup></configuration>

--- a/Gravity/Gravity.Test/Gravity.Test.csproj
+++ b/Gravity/Gravity.Test/Gravity.Test.csproj
@@ -37,17 +37,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="kCura.Data.RowDataGateway, Version=9.0.204.6, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\bin\9.3\kCura.Data.RowDataGateway.dll</HintPath>
+    <Reference Include="kCura.Data.RowDataGateway, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.RowDataGateway.9.5.162.111\lib\kCura.Data.RowDataGateway.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Relativity.Client, Version=9.0.204.6, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\bin\9.3\kCura.Relativity.Client.dll</HintPath>
+    <Reference Include="kCura.Relativity.Client, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.Rsapi.9.5.162.111\lib\kCura.Relativity.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.API, Version=9.0.204.6, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\bin\9.3\Relativity.API.dll</HintPath>
+    <Reference Include="Relativity.API, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.Api.9.5.162.111\lib\Relativity.API.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -84,6 +81,7 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/Gravity/Gravity.Test/Gravity.Test.csproj
+++ b/Gravity/Gravity.Test/Gravity.Test.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Gravity.Test</RootNamespace>
     <AssemblyName>Gravity.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Gravity/Gravity.Test/packages.config
+++ b/Gravity/Gravity.Test/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Relativity.Api" version="9.5.162.111" targetFramework="net452" />
+  <package id="Relativity.RowDataGateway" version="9.5.162.111" targetFramework="net452" />
+  <package id="Relativity.Rsapi" version="9.5.162.111" targetFramework="net452" />
+</packages>

--- a/Gravity/Gravity/Base/AppConfigConnectionHelper.cs
+++ b/Gravity/Gravity/Base/AppConfigConnectionHelper.cs
@@ -29,19 +29,38 @@ namespace Gravity.Base
 			return new UnitTestServicesManager();
 		}
 
-		public IUrlHelper GetUrlHelper()
-		{
-			throw new NotImplementedException();
-		}
+	    public IUrlHelper GetUrlHelper()
+	    {
+	        throw new NotImplementedException();
+	    }
 
-		public ILogFactory GetLoggerFactory()
-		{
-			throw new NotImplementedException();
-		}
+	    public ILogFactory GetLoggerFactory()
+	    {
+	        throw new NotImplementedException();
+	    }
 
-		public void Dispose()
+	    public string ResourceDBPrepend()
+	    {
+	        throw new NotImplementedException();
+	    }
+
+	    public string ResourceDBPrepend(IDBContext context)
+	    {
+	        throw new NotImplementedException();
+	    }
+
+	    public string GetSchemalessResourceDataBasePrepend(IDBContext context)
+	    {
+	        throw new NotImplementedException();
+	    }
+
+	    public Guid GetGuid(int workspaceID, int artifactID)
+	    {
+	        throw new NotImplementedException();
+	    }
+
+	    public void Dispose()
 		{
-			throw new NotImplementedException();
 		}
 	}
 

--- a/Gravity/Gravity/Base/AppConfigConnectionHelper.cs
+++ b/Gravity/Gravity/Base/AppConfigConnectionHelper.cs
@@ -29,37 +29,37 @@ namespace Gravity.Base
 			return new UnitTestServicesManager();
 		}
 
-	    public IUrlHelper GetUrlHelper()
-	    {
-	        throw new NotImplementedException();
-	    }
+		public IUrlHelper GetUrlHelper()
+		{
+			throw new NotImplementedException();
+		}
 
-	    public ILogFactory GetLoggerFactory()
-	    {
-	        throw new NotImplementedException();
-	    }
+		public ILogFactory GetLoggerFactory()
+		{
+			throw new NotImplementedException();
+		}
 
-	    public string ResourceDBPrepend()
-	    {
-	        throw new NotImplementedException();
-	    }
+		public string ResourceDBPrepend()
+		{
+			throw new NotImplementedException();
+		}
 
-	    public string ResourceDBPrepend(IDBContext context)
-	    {
-	        throw new NotImplementedException();
-	    }
+		public string ResourceDBPrepend(IDBContext context)
+		{
+			throw new NotImplementedException();
+		}
 
-	    public string GetSchemalessResourceDataBasePrepend(IDBContext context)
-	    {
-	        throw new NotImplementedException();
-	    }
+		public string GetSchemalessResourceDataBasePrepend(IDBContext context)
+		{
+			throw new NotImplementedException();
+		}
 
-	    public Guid GetGuid(int workspaceID, int artifactID)
-	    {
-	        throw new NotImplementedException();
-	    }
+		public Guid GetGuid(int workspaceID, int artifactID)
+		{
+			throw new NotImplementedException();
+		}
 
-	    public void Dispose()
+		public void Dispose()
 		{
 		}
 	}

--- a/Gravity/Gravity/Gravity.csproj
+++ b/Gravity/Gravity/Gravity.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Gravity</RootNamespace>
     <AssemblyName>Gravity</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,17 +32,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="kCura.Data.RowDataGateway, Version=9.0.204.6, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\bin\9.3\kCura.Data.RowDataGateway.dll</HintPath>
+    <Reference Include="kCura.Data.RowDataGateway, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.RowDataGateway.9.5.162.111\lib\kCura.Data.RowDataGateway.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Relativity.Client, Version=9.0.204.6, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\bin\9.3\kCura.Relativity.Client.dll</HintPath>
+    <Reference Include="kCura.Relativity.Client, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.Rsapi.9.5.162.111\lib\kCura.Relativity.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.API, Version=9.0.204.6, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\bin\9.3\Relativity.API.dll</HintPath>
+    <Reference Include="Relativity.API, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Relativity.Api.9.5.162.111\lib\Relativity.API.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -86,7 +84,11 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Exceptions\ProxyOperationFailedException.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Gravity/Gravity/packages.config
+++ b/Gravity/Gravity/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <!--9.5.162.11 is the last version to support net451-->
+  <package id="Relativity.Api" version="9.5.162.111" allowedVersions="[9.4.224.2, 9.5.162.111]" targetFramework="net451" />
+  <package id="Relativity.RowDataGateway" version="9.5.162.111" allowedVersions="[9.4.224.2, 9.5.162.111]" targetFramework="net451" />
+  <package id="Relativity.Rsapi" version="9.5.162.111" allowedVersions="[9.4.224.2, 9.5.162.111]" targetFramework="net451" />
+</packages>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CRUDQ Framework for Relativity Custom Development
 This is also available as a [nuget package].(https://www.nuget.org/packages/Gravity/)
 
 ## Target Framework
-* .NET 4.5.2
+* .NET 4.5.1
 
 ## Dependencies
 This project requires references to Relativity's Relativity® SDK dlls, which are referenced via Nuget packages. DLL versions 9.4.224.2 to 9.5.162.111, but these should generally work with earlier or later versions of a Relativity server without any problems.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,7 @@ This is also available as a [nuget package].(https://www.nuget.org/packages/Grav
 * .NET 4.5.2
 
 ## Dependencies
-This project requires references to Relativity's Relativity® SDK dlls. These dlls are not part of the open source project and can be obtained 
-by contacting support@relativity.com, getting it from your Relativity instance, or installing the SDK from the [Community Portal]
-(https://community.relativity.com/s/files).
-
-• kCura.Relativity.Client.dll 
-• Relativity.API.dll 
-• kCura.Data.RowDataGateway.dll 
+This project requires references to Relativity's Relativity® SDK dlls, which are referenced via Nuget packages. DLL versions 9.4.224.2 to 9.5.162.111, but these should generally work with earlier or later versions of a Relativity server without any problems.
 
 ## Samples
 Before using the CRUD/Q methods in Gravity you will have to create a model and decorate it with the appropriate attributes.


### PR DESCRIPTION
Fixes #10.
Also set the target framework to .NET 4.5.1 "for free"; it didn't break anything.
Please note that the minimum version of Relativity supported is 9.4.224.2 (the first one with a Nuget package), and the maximum one is 9.5.162.111 (the last one that can run under .NET 4.5.x). The underlying issue is discussed in #15.