### PR TITLE
refactor: refactor out retry/exception pattern for RSAPI calls

### DIFF
--- a/Gravity/Gravity/DAL/RSAPI/RsapiDao.Delete.cs
+++ b/Gravity/Gravity/DAL/RSAPI/RsapiDao.Delete.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Gravity.Base;
 using Gravity.Exceptions;
+using Gravity.Extensions;
 
 namespace Gravity.DAL.RSAPI
 {
@@ -12,47 +13,18 @@ namespace Gravity.DAL.RSAPI
 		#region RDO DELETE Protected stuff
 		protected void DeleteRDO(int artifactId)
 		{
-			using (var proxyToWorkspace = CreateProxy())
-			{
-				try
-				{
-					invokeWithRetryService.InvokeVoidMethodWithRetry(() => proxyToWorkspace.Repositories.RDO.DeleteSingle(artifactId));
-				}
-				catch (Exception ex)
-				{
-					throw new ProxyOperationFailedException("Failed in method: " + System.Reflection.MethodInfo.GetCurrentMethod(), ex);
-				}
-			}
+			InvokeProxyWithRetry(proxyToWorkspace => proxyToWorkspace.Repositories.RDO.DeleteSingle(artifactId));
 		}
 
 		protected void DeleteRDO(Guid artifactGuid)
 		{
-			using (var proxyToWorkspace = CreateProxy())
-			{
-				try
-				{
-					invokeWithRetryService.InvokeVoidMethodWithRetry(() => proxyToWorkspace.Repositories.RDO.DeleteSingle(artifactGuid));
-				}
-				catch (Exception ex)
-				{
-					throw new ProxyOperationFailedException("Failed in method: " + System.Reflection.MethodInfo.GetCurrentMethod(), ex);
-				}
-			}
+			InvokeProxyWithRetry(proxyToWorkspace => proxyToWorkspace.Repositories.RDO.DeleteSingle(artifactGuid));
 		}
 
 		protected void DeleteRDOs(List<int> artifactIds)
 		{
-			using (var proxyToWorkspace = CreateProxy())
-			{
-				try
-				{
-					invokeWithRetryService.InvokeVoidMethodWithRetry(() => proxyToWorkspace.Repositories.RDO.Delete(artifactIds));
-				}
-				catch (Exception ex)
-				{
-					throw new ProxyOperationFailedException("Failed in method: " + System.Reflection.MethodInfo.GetCurrentMethod(), ex);
-				}
-			}
+			InvokeProxyWithRetry(proxyToWorkspace => proxyToWorkspace.Repositories.RDO.Delete(artifactIds))
+				.GetResultData(); //ensure no exceptions
 		}
 		#endregion
 

--- a/Gravity/Gravity/DAL/RSAPI/RsapiDao.Get.Document.cs
+++ b/Gravity/Gravity/DAL/RSAPI/RsapiDao.Get.Document.cs
@@ -24,19 +24,7 @@ namespace Gravity.DAL.RSAPI
 				Fields = FieldValue.SelectedFields
 			};
 
-			using (IRSAPIClient proxy = CreateProxy())
-			{
-				try
-				{
-					returnObject = invokeWithRetryService.InvokeWithRetry(() => proxy.Repositories.Document.Query(query));
-				}
-				catch (Exception ex)
-				{
-					throw new ProxyOperationFailedException("Failed in method: " + MethodBase.GetCurrentMethod(), ex);
-				}
-			}
-
-			return returnObject;
+			return InvokeProxyWithRetry(proxy => proxy.Repositories.Document.Query(query));
 		}
 
 		public KeyValuePair<byte[], FileMetadata> DownloadDocumentNative(int documentId)
@@ -44,19 +32,8 @@ namespace Gravity.DAL.RSAPI
 			Document doc = new Document(documentId);
 			byte[] documentBytes;
 
-			KeyValuePair<DownloadResponse, Stream> documentNativeResponse = new KeyValuePair<DownloadResponse, Stream>();
-
-			using (IRSAPIClient proxy = CreateProxy())
-			{
-				try
-				{
-					documentNativeResponse = invokeWithRetryService.InvokeWithRetry(() => proxy.Repositories.Document.DownloadNative(doc));
-				}
-				catch (Exception ex)
-				{
-					throw new ProxyOperationFailedException("Failed in method: " + MethodInfo.GetCurrentMethod(), ex);
-				}
-			}
+			KeyValuePair<DownloadResponse, Stream> documentNativeResponse
+				= InvokeProxyWithRetry(proxy => proxy.Repositories.Document.DownloadNative(doc));
 
 			using (MemoryStream ms = (MemoryStream)documentNativeResponse.Value)
 			{

--- a/Gravity/Gravity/DAL/RSAPI/RsapiDao.Insert.cs
+++ b/Gravity/Gravity/DAL/RSAPI/RsapiDao.Insert.cs
@@ -16,18 +16,7 @@ namespace Gravity.DAL.RSAPI
 		#region RDO INSERT Protected Stuff
 		protected int InsertRdo(RDO newRdo)
 		{
-			int resultArtifactId = 0;
-			using (var proxyToWorkspace = CreateProxy())
-			{
-				try
-				{
-					resultArtifactId = invokeWithRetryService.InvokeWithRetry(() => proxyToWorkspace.Repositories.RDO.CreateSingle(newRdo));
-				}
-				catch (Exception ex)
-				{
-					throw new ProxyOperationFailedException("Failed in method: " + System.Reflection.MethodInfo.GetCurrentMethod(), ex);
-				}
-			}
+			var resultArtifactId = InvokeProxyWithRetry(proxyToWorkspace => proxyToWorkspace.Repositories.RDO.CreateSingle(newRdo));
 
 			if (resultArtifactId <= 0)
 			{
@@ -39,21 +28,7 @@ namespace Gravity.DAL.RSAPI
 
 		protected WriteResultSet<RDO> InsertRdos(params RDO[] newRdos)
 		{
-			WriteResultSet<RDO> resultSet = new WriteResultSet<RDO>();
-
-			using (var proxyToWorkspace = CreateProxy())
-			{
-				try
-				{
-					resultSet = invokeWithRetryService.InvokeWithRetry(() => proxyToWorkspace.Repositories.RDO.Create(newRdos));
-				}
-				catch (Exception ex)
-				{
-					throw new ProxyOperationFailedException("Failed in method: " + System.Reflection.MethodInfo.GetCurrentMethod(), ex);
-				}
-			}
-
-			return resultSet;
+			return InvokeProxyWithRetry(proxyToWorkspace => proxyToWorkspace.Repositories.RDO.Create(newRdos));
 		}
 
 		protected void InsertUpdateFileField(BaseDto objectToInsert, int parentId)
@@ -79,14 +54,7 @@ namespace Gravity.DAL.RSAPI
 									uploadRequest.Target.FieldId = relativityFile.ArtifactTypeId;
 									uploadRequest.Target.ObjectArtifactId = parentId;
 
-									try
-									{
-										invokeWithRetryService.InvokeVoidMethodWithRetry(() => proxyToWorkspace.Upload(uploadRequest));
-									}
-									catch (Exception ex)
-									{
-										throw ex;
-									}
+									InvokeProxyWithRetry(proxyToWorkspace, proxy => proxy.Upload(uploadRequest));
 								}
 							}
 							else if (string.IsNullOrEmpty(relativityFile.FileMetadata.FileName) == false)
@@ -107,11 +75,9 @@ namespace Gravity.DAL.RSAPI
 
 									try
 									{
-										invokeWithRetryService.InvokeVoidMethodWithRetry(() => proxyToWorkspace.Upload(uploadRequest));
-
-										invokeWithRetryService.InvokeVoidMethodWithRetry(() => System.IO.File.Delete(fileName));
+										InvokeProxyWithRetry(proxyToWorkspace, proxy => proxy.Upload(uploadRequest));
 									}
-									catch (Exception)
+									finally
 									{
 										invokeWithRetryService.InvokeVoidMethodWithRetry(() => System.IO.File.Delete(fileName));
 									}
@@ -140,14 +106,7 @@ namespace Gravity.DAL.RSAPI
 							uploadRequest.Target.FieldId = relativityFile.ArtifactTypeId;
 							uploadRequest.Target.ObjectArtifactId = parentId;
 
-							try
-							{
-								invokeWithRetryService.InvokeVoidMethodWithRetry(() => proxyToWorkspace.Upload(uploadRequest));
-							}
-							catch (Exception ex)
-							{
-								throw ex;
-							}
+							InvokeProxyWithRetry(proxyToWorkspace, proxy => proxy.Upload(uploadRequest));
 						}
 					}
 					else if (string.IsNullOrEmpty(relativityFile.FileMetadata.FileName) == false)
@@ -168,11 +127,9 @@ namespace Gravity.DAL.RSAPI
 
 							try
 							{
-								invokeWithRetryService.InvokeVoidMethodWithRetry(() => proxyToWorkspace.Upload(uploadRequest));
-
-								invokeWithRetryService.InvokeVoidMethodWithRetry(() => System.IO.File.Delete(fileName));
+								InvokeProxyWithRetry(proxyToWorkspace, proxy => proxy.Upload(uploadRequest));
 							}
-							catch (Exception)
+							finally
 							{
 								invokeWithRetryService.InvokeVoidMethodWithRetry(() => System.IO.File.Delete(fileName));
 							}

--- a/Gravity/Gravity/DAL/RSAPI/RsapiDao.Update.cs
+++ b/Gravity/Gravity/DAL/RSAPI/RsapiDao.Update.cs
@@ -15,36 +15,12 @@ namespace Gravity.DAL.RSAPI
 		#region UPDATE Protected Stuff
 		protected WriteResultSet<RDO> UpdateRdos(params RDO[] rdos)
 		{
-			WriteResultSet<RDO> resultSet = new WriteResultSet<RDO>();
-
-			using (var proxyToWorkspace = CreateProxy())
-			{
-				try
-				{
-					resultSet = invokeWithRetryService.InvokeWithRetry(() => proxyToWorkspace.Repositories.RDO.Update(rdos));
-				}
-				catch (Exception ex)
-				{
-					throw new ProxyOperationFailedException("Failed in method: " + System.Reflection.MethodInfo.GetCurrentMethod(), ex);
-				}
-			}
-
-			return resultSet;
+			return InvokeProxyWithRetry(proxyToWorkspace => proxyToWorkspace.Repositories.RDO.Update(rdos));
 		}
 
 		protected void UpdateRdo(RDO theRdo)
 		{
-			using (var proxyToWorkspace = CreateProxy())
-			{
-				try
-				{
-					invokeWithRetryService.InvokeVoidMethodWithRetry(() => proxyToWorkspace.Repositories.RDO.UpdateSingle(theRdo));
-				}
-				catch (Exception ex)
-				{
-					throw new ProxyOperationFailedException("Failed in method: " + System.Reflection.MethodInfo.GetCurrentMethod(), ex);
-				}
-			}
+			InvokeProxyWithRetry(proxyToWorkspace => proxyToWorkspace.Repositories.RDO.UpdateSingle(theRdo));
 		}
 		#endregion
 

--- a/Gravity/Gravity/Extensions/ResultSetExtensions.cs
+++ b/Gravity/Gravity/Extensions/ResultSetExtensions.cs
@@ -1,0 +1,23 @@
+﻿using kCura.Relativity.Client.DTOs;
+using kCura.Relativity.Client.Repositories;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Gravity.Extensions
+{
+    public static class ResultSetExtensions
+    {
+		public static List<T> GetResultData<T>(this ResultSet<T> results) where T: Artifact
+		{
+			if (!results.Success)
+				throw new InvalidOperationException("Query failure: " + results.Message);
+
+			return results.Results.Select(x =>
+				x.Success ? x.Artifact : throw new InvalidOperationException("Query item failure: " + x.Message)
+			).ToList();
+		}
+	}
+}

--- a/Gravity/Gravity/Gravity.csproj
+++ b/Gravity/Gravity/Gravity.csproj
@@ -63,6 +63,7 @@
     <Compile Include="DAL\RSAPI\RsapiDao.Get.Document.cs" />
     <Compile Include="Extensions\BaseDtoExtensions.cs" />
     <Compile Include="Extensions\CollectionsExtensions.cs" />
+    <Compile Include="Extensions\ResultSetExtensions.cs" />
     <Compile Include="Extensions\EnumHelpers.cs" />
     <Compile Include="Globals\SQLConstants.cs" />
     <Compile Include="Utils\InvokeWithRetrySettings.cs" />


### PR DESCRIPTION
The try/catch ceremony was getting in they way of implementing #8, so I refactored it out. I ran the unit tests (except for the recursive-delete one).

There are a couple of changed behaviors:
- If a single item fails from a result set, an exception is thrown.
- failed file uploads throw exceptions.
- `InsertUpdateFileField` failures are wrapped in a `ProxyOperationFailedException`.
- `DeleteRDOs` checks for deletion success.